### PR TITLE
fix OAuth support check

### DIFF
--- a/gst/milestonexprotect/milestonexprotect.py
+++ b/gst/milestonexprotect/milestonexprotect.py
@@ -83,8 +83,11 @@ def get_oauth_token(hostname: str, domain: str, username: str, password: str) ->
 
   # Check server version supports OAuth
   matches = re.findall(r"(\d+)\.(\d+)\.(\d+)", body["server_version"])
-  if matches is None or int(matches[0][0]) < 21:
-      return None
+  try:
+    if int(matches[0][0]) < 21:
+        return None
+  except:
+    return None
 
   token_endpoint = body["token_endpoint"]
   data = {


### PR DESCRIPTION
Hi!
This PR fixes exception on connection of this kind:
```
Setting pipeline to PAUSED ...
Traceback (most recent call last):
  File "/usr/lib/x86_64-linux-gnu/gstreamer-1.0/python/milestonexprotect.py", line 374, in do_start
    wsdl, session = get_wsdl()
                    ^^^^^^^^^^
  File "/usr/lib/x86_64-linux-gnu/gstreamer-1.0/python/milestonexprotect.py", line 345, in get_wsdl
    oauth = get_oauth_token(self.management_server, self.user_domain, self.user_id, self.user_pw) if not bypass_oauth else None
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/x86_64-linux-gnu/gstreamer-1.0/python/milestonexprotect.py", line 87, in get_oauth_token
    if matches is None or int(matches[0][0]) < 21:
                              ~~~~~~~^^^
IndexError: list index out of range
ERROR: from element /GstPipeline:pipeline0/milestonexprotect+MilestoneXprotectSrc:milestonexprotect+milestonexprotectsrc0: GStreamer error: state change failed and some element failed to post a proper error message with the reason for the failure.
Additional debug info:
../libs/gst/base/gstbasesrc.c(3606): gst_base_src_start (): /GstPipeline:pipeline0/milestonexprotect+MilestoneXprotectSrc:milestonexprotect+milestonexprotectsrc0:
Failed to start
ERROR: pipeline doesn't want to preroll.
Failed to set pipeline to PAUSED.
Setting pipeline to NULL ...
Freeing pipeline ...
```