### PR TITLE
Add option to apply timestamp metadata to buffer

### DIFF
--- a/gst/vpsxprotect/gstvpsfromxprotectconverter.cpp
+++ b/gst/vpsxprotect/gstvpsfromxprotectconverter.cpp
@@ -230,6 +230,12 @@ static GstFlowReturn gst_fromxprotectconverter_chain(GstPad * pad, GstObject * p
   GST_BUFFER_PTS(outputBuffer) = GST_BUFFER_PTS(buf);
   GST_BUFFER_OFFSET(outputBuffer) = GST_BUFFER_OFFSET(buf);
 
+  // Copy reference timestamp metadata if present
+  GstReferenceTimestampMeta *meta = gst_buffer_get_reference_timestamp_meta(buf, NULL);
+  if (meta) {
+    gst_buffer_add_reference_timestamp_meta(outputBuffer, meta->reference, meta->timestamp, meta->duration);
+  }
+
   // Theoretically, we can just modify the buffer in-place
   // TODO: Look into this
   memcpy(info2.data, gbd->GetBody(), gbd->GetBodyLength());


### PR DESCRIPTION
Hi!

We have a bit of a selfish feature-add to this that might be useful to others. Basically just adding an option to enable writing timestamps to each buffer through `GstReferenceTimestampMeta`. No offense taken if you don't accept PRs though.

Cheers!